### PR TITLE
Add CC0 license info to templates

### DIFF
--- a/Templates/Readme.md
+++ b/Templates/Readme.md
@@ -3,6 +3,7 @@
 * The contents of a **Readme.md** will show up embedded on the top of the folder it is in (in the web interface and the mobile apps)
 * Formatting is supported with the bar on top (using Markdown)
 * It uses Nextcloud Text so you can collaborate on it 🎉
+* You can use and remix the templates as you like, they are in the public domain via the [CC0 license](https://creativecommons.org/publicdomain/zero/1.0/)
 
 ## Action items
 


### PR DESCRIPTION
As per @mmeeks’ recommendation – thanks for the catch! The rest of the example files are CC Attribution as mentioned in https://github.com/nextcloud/example-files/blob/master/Documents/Example.md, but for templates CC0 is indeed better.

Please review @juliushaertl @jospoortvliet 

(We can’t have a dedicated license file in this folder because then, well, it would end up as a template. ;)